### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/onlydevices/32eaa8f7-4feb-437c-bf93-f9d55f708f9e/ab5bb64f-6713-4333-8b2a-abc2a06ea027/_apis/work/boardbadge/21528789-ecf6-4ff5-bef6-5c16e85d935f)](https://dev.azure.com/onlydevices/32eaa8f7-4feb-437c-bf93-f9d55f708f9e/_boards/board/t/ab5bb64f-6713-4333-8b2a-abc2a06ea027/Microsoft.RequirementCategory)
 # hello-world
 Getting started
 version 2


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/onlydevices/32eaa8f7-4feb-437c-bf93-f9d55f708f9e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.